### PR TITLE
Translations update from transLIT

### DIFF
--- a/src/langs/ja-KANA.json
+++ b/src/langs/ja-KANA.json
@@ -1,0 +1,4 @@
+{
+    "SETTING_LANGUAGE_EN": "えいご",
+    "SETTING_LANGUAGE_FI": "フィンランドご"
+}

--- a/src/langs/ja.json
+++ b/src/langs/ja.json
@@ -1,1 +1,5 @@
-{}
+{
+    "SETTING_LANGUAGE_FI": "フィンランド語",
+    "SETTING_LANGUAGE_EN": "英語",
+    "SETTING_LANGUAGE_JA": "日本語"
+}

--- a/src/langs/nb_NO.json
+++ b/src/langs/nb_NO.json
@@ -63,5 +63,11 @@
     "SETTINGS_USERSETTINGS": "Brukerinnstillinger",
     "CREDITS_LEGAL_NOTICE_TUMBLR": "Denne applikasjonen bruker Tumblr sitt programmeringsgrensesnitt men er ikke godkjent eller sertifisert av Tumblr, Inc. Alle Tumblr-logoer og varemerker vist i denne applikasjonen tilhører Tumblr, Inc.",
     "SETTINGS_APPSETTINGS": "Quarky-innstillinger",
-    "SUPPORT_BUTTON": "Kundestøtte"
+    "SUPPORT_BUTTON": "Kundestøtte",
+    "SETTINGS_LANGUAGE_INVITE": "Du kan hjelpe med oversettelse på <0>transLIT</0>!",
+    "SETTINGS_LANGUAGE": "Språk",
+    "SETTING_LANGUAGE_EN": "Engelsk",
+    "SETTING_LANGUAGE_FI": "Finsk",
+    "SETTING_LANGUAGE_JA": "Japansk",
+    "SETTING_LANGUAGE_NB_NO": "Norsk bokmål"
 }


### PR DESCRIPTION
Translations update from [transLIT](https://translit.litdevs.org) for [Quarky/Quarky Web](https://translit.litdevs.org/projects/quarky/quarky/).



Current translation status:

![Weblate translation status](https://translit.litdevs.org/widget/quarky/quarky/horizontal-auto.svg)